### PR TITLE
Add explicit dependency on python-requirement.

### DIFF
--- a/playbooks/base.yml
+++ b/playbooks/base.yml
@@ -2,4 +2,5 @@
 - hosts: all
   remote_user: root
   roles:
+    - { role: FGtatsuro.python-requirements }
     - { role: FGtatsuro.ruby }

--- a/role_requirements.yml
+++ b/role_requirements.yml
@@ -6,4 +6,5 @@
 - src: FGtatsuro.docker-toolbox
 
 # For base
+- src: FGtatsuro.python-requirements
 - src: FGtatsuro.ruby


### PR DESCRIPTION
This role was used via ruby role implicitly, but it's better to be
explicit.
