### PR TITLE
Fix bug for apt module to misunderstand cache validation.

### DIFF
--- a/platforms/docker/debian.json
+++ b/platforms/docker/debian.json
@@ -43,7 +43,8 @@
                 {
                         "type": "shell",
                         "inline": [
-                                "rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/apt/archives/*",
+                                "rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/apt/archives/* /var/lib/apt/periodic/update-success-stamp",
+                                "touch -d '2000/1/1 00:00:00' /var/lib/apt/lists/",
                                 "rm -rf /root/.cache /var/lib/gems/2.1.0/cache/*",
                                 "rm -rf /usr/share/doc/* && rm -rf /usr/share/info/*"
                         ]


### PR DESCRIPTION
Ref. https://github.com/ansible/ansible-modules-core/blob/99cd31140dc0b2b64c994d729d3c93dc2ad7e63b/packaging/os/apt.py#L685
