### PR TITLE
Workaround for installation of ansible 2.1.0 on Linux.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ matrix:
       language: generic
       env:
         - PYTHONPATH="/Library/Python/2.7/site-packages:$PYTHONPATH"
+      install:
+        - sudo pip install -U setuptools
+        - sudo pip install -r requirements.txt
+        - ansible-galaxy install -r role_requirements.yml
+        - bundle install
       script:
         - ansible-playbook playbooks/buildenv.yml -i tests/inventory -l localhost -vvvv
         - bundle exec rake spec SPEC_TARGET=localhost
@@ -81,8 +86,7 @@ matrix:
 sudo: required
 
 install:
-  - sudo pip install -U setuptools
-  - sudo pip install -r requirements.txt
+  - pip install -r requirements.txt
   - ansible-galaxy install -r role_requirements.yml
   - bundle install
 script:


### PR DESCRIPTION
'sudo pip install' causes error on Linux.
